### PR TITLE
Save and modify title input fieldsfor task

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -55,12 +55,14 @@ impl App {
         app.task_list.items = vec![
           Task{
               id:0,
+              title: "Task 1 title".to_string(),
               description: "Task 1".to_string(),
               completed: true,
               priority: Priority::Low
           },
           Task{
               id:1,
+              title: "Task 2 title".to_string(),
               description: "Task 2".to_string(),
               completed: false,
               priority: Priority::High
@@ -111,8 +113,10 @@ impl App {
 pub struct AddTaskCommand;
 impl Command for AddTaskCommand {
     fn execute(&mut self, app: &mut App) {
-        let _: String = app.input_title.drain(..).collect();
-        app.tasks_service.add_task_with_priority(app.input_description.drain(..).collect(), Priority::Low);
+        let mut t = Task::new();
+        t.title = app.input_title.drain(..).collect();
+        t.description = app.input_description.drain(..).collect();
+        app.tasks_service.add_new_task(&t);
         app.refresh_task_list();
     }
 }
@@ -144,10 +148,12 @@ impl Command for ToggleItemPriorityCommand {
     }
 }
 
+/// Start editing a task
 pub struct StartEditingTaskCommand;
 impl Command for StartEditingTaskCommand {
     fn execute(&mut self, app: &mut App) {
         if let Some(index) = app.task_list.state.selected() {
+            // TODO: take value from input field
             app.input_title = String::new();
             app.input_description = app.task_list.items[index].description.clone();
             app.input_mode = InputMode::EditingExisting;
@@ -160,6 +166,7 @@ pub struct FinishEditingTaskCommand;
 impl Command for FinishEditingTaskCommand {
     fn execute(&mut self, app: &mut App) {
         if let Some(index) = app.task_list.state.selected() {
+            // TODO: copy value into app input_title and write on DB
             let _: String = app.input_title.drain(..).collect();
             app.task_list.items[index].description = app.input_description.drain(..).collect();
             app.tasks_service.update_description(app.task_list.items[index].id, app.task_list.items[index].description.as_str())

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,5 +1,4 @@
 use ratatui::widgets::ListState;
-use crate::command::Command;
 use crate::task::{Priority, Task};
 use crate::task_manager::TasksService;
 
@@ -105,97 +104,5 @@ impl App {
             //InputField::Description => InputField::Date,
             InputField::Description => InputField::Title,
         }
-    }
-}
-
-
-pub struct EnterEditModeCommand;
-impl Command for EnterEditModeCommand {
-    fn execute(&mut self, app: &mut App) {
-        app.input_mode = InputMode::Editing;
-        app.input_field = InputField::Title;
-    }
-}
-
-/// Add a new task
-pub struct AddTaskCommand;
-impl Command for AddTaskCommand {
-    fn execute(&mut self, app: &mut App) {
-        let mut t = Task::new();
-        t.title = app.input_title.drain(..).collect();
-        t.description = app.input_description.drain(..).collect();
-        app.tasks_service.add_new_task(&t);
-        app.refresh_task_list();
-    }
-}
-
-/// Toggle completed for selected task status
-pub struct ToggleTaskStatusCommand;
-impl Command for ToggleTaskStatusCommand {
-    fn execute(&mut self, app: &mut App) {
-        if let Some(index) = app.task_list.state.selected(){
-            let item = &mut app.task_list.items[index];
-            item.completed = match item.completed {
-                true => false,
-                false => true,
-            };
-            let _ = app.tasks_service.toggle_task_status(item.id, item.completed);
-        };
-    }
-}
-
-/// Switch between priorities
-pub struct ToggleItemPriorityCommand;
-impl Command for ToggleItemPriorityCommand {
-    fn execute(&mut self, app: &mut App) {
-        if let Some(index) = app.task_list.state.selected() {
-            let item = &mut app.task_list.items[index];
-            item.priority = item.priority.next();
-            app.tasks_service.change_priority(item.id, &item.priority);
-        }
-    }
-}
-
-/// Start editing a task
-pub struct StartEditingExistingTaskCommand;
-impl Command for StartEditingExistingTaskCommand {
-    fn execute(&mut self, app: &mut App) {
-        if let Some(index) = app.task_list.state.selected() {
-            app.input_title = app.task_list.items[index].title.clone();
-            app.input_description = app.task_list.items[index].description.clone();
-            app.input_mode = InputMode::EditingExisting;
-            app.input_field = InputField::Title;
-        }
-    }
-}
-
-pub struct FinishEditingExistingTaskCommand;
-impl Command for FinishEditingExistingTaskCommand {
-    fn execute(&mut self, app: &mut App) {
-        if let Some(index) = app.task_list.state.selected() {
-            app.task_list.items[index].title = app.input_title.drain(..).collect();
-            app.task_list.items[index].description = app.input_description.drain(..).collect();
-            app.tasks_service.update_task(&app.task_list.items[index])
-        }
-        app.input_mode = InputMode::Normal;
-    }
-}
-
-pub struct DeleteTaskCommand;
-impl Command for DeleteTaskCommand {
-    fn execute(&mut self, app: &mut App) {
-        if let Some(index) = app.task_list.state.selected() {
-            app.tasks_service.delete_task(app.task_list.items[index].id);
-            app.task_list.items.remove(index);
-        }
-    }
-}
-
-pub struct StopEditingCommand;
-impl Command for StopEditingCommand {
-    fn execute(&mut self, app: &mut App) {
-        app.input_mode = InputMode::Normal;
-        app.input_title.clear();
-        app.input_description.clear();
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,6 +1,6 @@
-use ratatui::widgets::ListState;
 use crate::task::{Priority, Task};
 use crate::task_manager::TasksService;
+use ratatui::widgets::ListState;
 
 pub struct TaskList {
     pub items: Vec<Task>,
@@ -11,12 +11,12 @@ impl TaskList {
     pub fn new() -> TaskList {
         TaskList {
             items: vec![],
-            state: ListState::default()
+            state: ListState::default(),
         }
     }
 }
 #[derive(Debug)]
-pub enum InputMode{
+pub enum InputMode {
     Normal,
     Editing,
     EditingExisting,
@@ -34,7 +34,7 @@ pub struct App {
     pub input_description: String,
     pub input_mode: InputMode,
     pub input_field: InputField,
-    pub tasks_service: TasksService
+    pub tasks_service: TasksService,
 }
 
 impl App {
@@ -52,26 +52,28 @@ impl App {
     pub fn test() -> App {
         let mut app = App::new();
         app.task_list.items = vec![
-          Task{
-              id:0,
-              title: "Task 1 title".to_string(),
-              description: "Task 1".to_string(),
-              completed: true,
-              priority: Priority::Low
-          },
-          Task{
-              id:1,
-              title: "Task 2 title".to_string(),
-              description: "Task 2".to_string(),
-              completed: false,
-              priority: Priority::High
-          },
+            Task {
+                id: 0,
+                title: "Task 1 title".to_string(),
+                description: "Task 1".to_string(),
+                completed: true,
+                priority: Priority::Low,
+            },
+            Task {
+                id: 1,
+                title: "Task 2 title".to_string(),
+                description: "Task 2".to_string(),
+                completed: false,
+                priority: Priority::High,
+            },
         ];
         app
     }
 
     pub fn sort_by_priority(&mut self) {
-        self.task_list.items.sort_by(|a, b| b.priority.cmp(&a.priority))
+        self.task_list
+            .items
+            .sort_by(|a, b| b.priority.cmp(&a.priority))
     }
 
     pub fn select_none(&mut self) {
@@ -94,7 +96,7 @@ impl App {
         self.task_list.state.select_last();
     }
 
-    pub fn refresh_task_list(&mut self){
+    pub fn refresh_task_list(&mut self) {
         self.task_list.items = self.tasks_service.get_all_tasks()
     }
 

--- a/src/command.rs
+++ b/src/command.rs
@@ -32,13 +32,15 @@ pub struct ToggleTaskStatusCommand;
 
 impl Command for ToggleTaskStatusCommand {
     fn execute(&mut self, app: &mut App) {
-        if let Some(index) = app.task_list.state.selected(){
+        if let Some(index) = app.task_list.state.selected() {
             let item = &mut app.task_list.items[index];
             item.completed = match item.completed {
                 true => false,
                 false => true,
             };
-            let _ = app.tasks_service.toggle_task_status(item.id, item.completed);
+            let _ = app
+                .tasks_service
+                .toggle_task_status(item.id, item.completed);
         };
     }
 }

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,5 +1,109 @@
-use crate::app::App;
+use crate::app::{App, InputField, InputMode};
+use crate::task::Task;
 
 pub trait Command {
     fn execute(&mut self, app: &mut App);
+}
+
+pub struct EnterEditModeCommand;
+
+impl Command for EnterEditModeCommand {
+    fn execute(&mut self, app: &mut App) {
+        app.input_mode = InputMode::Editing;
+        app.input_field = InputField::Title;
+    }
+}
+
+/// Add a new task
+pub struct AddTaskCommand;
+
+impl Command for AddTaskCommand {
+    fn execute(&mut self, app: &mut App) {
+        let mut t = Task::new();
+        t.title = app.input_title.drain(..).collect();
+        t.description = app.input_description.drain(..).collect();
+        app.tasks_service.add_new_task(&t);
+        app.refresh_task_list();
+    }
+}
+
+/// Toggle completed for selected task status
+pub struct ToggleTaskStatusCommand;
+
+impl Command for ToggleTaskStatusCommand {
+    fn execute(&mut self, app: &mut App) {
+        if let Some(index) = app.task_list.state.selected(){
+            let item = &mut app.task_list.items[index];
+            item.completed = match item.completed {
+                true => false,
+                false => true,
+            };
+            let _ = app.tasks_service.toggle_task_status(item.id, item.completed);
+        };
+    }
+}
+
+/// Switch between priorities
+pub struct ToggleItemPriorityCommand;
+
+impl Command for ToggleItemPriorityCommand {
+    fn execute(&mut self, app: &mut App) {
+        if let Some(index) = app.task_list.state.selected() {
+            let item = &mut app.task_list.items[index];
+            item.priority = item.priority.next();
+            app.tasks_service.change_priority(item.id, &item.priority);
+        }
+    }
+}
+
+/// Start editing a task, move cursor to Title input field
+/// and set InputMode equal to InputMode::EditingExisting
+pub struct StartEditingExistingTaskCommand;
+
+impl Command for StartEditingExistingTaskCommand {
+    fn execute(&mut self, app: &mut App) {
+        if let Some(index) = app.task_list.state.selected() {
+            app.input_title = app.task_list.items[index].title.clone();
+            app.input_description = app.task_list.items[index].description.clone();
+            app.input_mode = InputMode::EditingExisting;
+            app.input_field = InputField::Title;
+        }
+    }
+}
+
+/// Finish editing an existing task, set InputMode back to Normal
+pub struct FinishEditingExistingTaskCommand;
+
+impl Command for FinishEditingExistingTaskCommand {
+    fn execute(&mut self, app: &mut App) {
+        if let Some(index) = app.task_list.state.selected() {
+            app.task_list.items[index].title = app.input_title.drain(..).collect();
+            app.task_list.items[index].description = app.input_description.drain(..).collect();
+            app.tasks_service.update_task(&app.task_list.items[index])
+        }
+        app.input_mode = InputMode::Normal;
+    }
+}
+
+pub struct DeleteTaskCommand;
+
+impl Command for DeleteTaskCommand {
+    fn execute(&mut self, app: &mut App) {
+        if let Some(index) = app.task_list.state.selected() {
+            app.tasks_service.delete_task(app.task_list.items[index].id);
+            app.task_list.items.remove(index);
+        }
+    }
+}
+
+/// Stop adding or editing the current task, clear the input fields and
+/// set InputMode back to Normal
+pub struct StopEditingCommand;
+
+impl Command for StopEditingCommand {
+    fn execute(&mut self, app: &mut App) {
+        app.input_mode = InputMode::Normal;
+        app.input_title.clear();
+        app.input_description.clear();
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,6 @@
+pub mod app;
+pub mod command;
+pub mod task;
 pub mod task_db;
 pub mod task_manager;
-pub mod app;
 pub mod ui;
-pub mod task;
-pub mod command;
-
-

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,11 +3,10 @@ use ratatui::crossterm::event;
 use ratatui::Terminal;
 use std::error::Error;
 use std::io;
-use task_rustler::app::{AddTaskCommand, App, DeleteTaskCommand, EnterEditModeCommand,
-                        FinishEditingExistingTaskCommand, InputField, InputMode,
-                        StartEditingExistingTaskCommand, StopEditingCommand,
-                        ToggleItemPriorityCommand, ToggleTaskStatusCommand};
-use task_rustler::command::Command;
+use task_rustler::app::{App,
+                        InputField, InputMode
+};
+use task_rustler::command::*;
 use task_rustler::ui;
 
 fn main() -> Result<(), Box<dyn Error>> {
@@ -31,6 +30,7 @@ fn run_app<B: ratatui::backend::Backend>(
         terminal.draw(|f| ui::ui(f, &mut app))?;
 
         if let Event::Key(key) = event::read()? {
+            // Capture only press key event
             if key.kind == event::KeyEventKind::Release {
                 continue;
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,9 @@
-use ratatui::crossterm::event::{Event, KeyCode};
 use ratatui::crossterm::event;
+use ratatui::crossterm::event::{Event, KeyCode};
 use ratatui::Terminal;
 use std::error::Error;
 use std::io;
-use task_rustler::app::{App,
-                        InputField, InputMode
-};
+use task_rustler::app::{App, InputField, InputMode};
 use task_rustler::command::*;
 use task_rustler::ui;
 
@@ -73,18 +71,18 @@ fn run_app<B: ratatui::backend::Backend>(
                         app.input_mode = InputMode::Normal;
                     }
                     KeyCode::Tab => app.next_input_field(),
-                    KeyCode::Char(c) => {
-                        match app.input_field {
-                            InputField::Title => app.input_title.push(c),
-                            InputField::Description => app.input_description.push(c),
+                    KeyCode::Char(c) => match app.input_field {
+                        InputField::Title => app.input_title.push(c),
+                        InputField::Description => app.input_description.push(c),
+                    },
+                    KeyCode::Backspace => match app.input_field {
+                        InputField::Title => {
+                            app.input_title.pop();
                         }
-                    }
-                    KeyCode::Backspace => {
-                        match app.input_field {
-                            InputField::Title => {app.input_title.pop();},
-                            InputField::Description => {app.input_description.pop();}
+                        InputField::Description => {
+                            app.input_description.pop();
                         }
-                    }
+                    },
                     KeyCode::Esc => {
                         StopEditingCommand.execute(&mut app);
                     }
@@ -95,18 +93,18 @@ fn run_app<B: ratatui::backend::Backend>(
                     KeyCode::Enter => {
                         FinishEditingExistingTaskCommand.execute(&mut app);
                     }
-                    KeyCode::Char(c) => {
-                        match app.input_field {
-                            InputField::Title => app.input_title.push(c),
-                            InputField::Description => app.input_description.push(c),
+                    KeyCode::Char(c) => match app.input_field {
+                        InputField::Title => app.input_title.push(c),
+                        InputField::Description => app.input_description.push(c),
+                    },
+                    KeyCode::Backspace => match app.input_field {
+                        InputField::Title => {
+                            app.input_title.pop();
                         }
-                    }
-                    KeyCode::Backspace => {
-                        match app.input_field {
-                            InputField::Title => {app.input_title.pop();},
-                            InputField::Description => {app.input_description.pop();}
+                        InputField::Description => {
+                            app.input_description.pop();
                         }
-                    }
+                    },
                     KeyCode::Esc => {
                         StopEditingCommand.execute(&mut app);
                     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,8 +3,10 @@ use ratatui::crossterm::event;
 use ratatui::Terminal;
 use std::error::Error;
 use std::io;
-use task_rustler::app::{AddTaskCommand, App, DeleteTaskCommand, FinishEditingTaskCommand, InputField,
-                        InputMode, StartEditingTaskCommand, ToggleItemPriorityCommand, ToggleTaskStatusCommand};
+use task_rustler::app::{AddTaskCommand, App, DeleteTaskCommand, EnterEditModeCommand,
+                        FinishEditingExistingTaskCommand, InputField, InputMode,
+                        StartEditingExistingTaskCommand, StopEditingCommand,
+                        ToggleItemPriorityCommand, ToggleTaskStatusCommand};
 use task_rustler::command::Command;
 use task_rustler::ui;
 
@@ -35,8 +37,7 @@ fn run_app<B: ratatui::backend::Backend>(
             match app.input_mode {
                 InputMode::Normal => match key.code {
                     KeyCode::Char('e') => {
-                        app.input_mode = InputMode::Editing;
-                        app.input_field =InputField::Title;
+                        EnterEditModeCommand.execute(&mut app);
                     }
                     KeyCode::Char('q') => {
                         return Ok(());
@@ -51,7 +52,7 @@ fn run_app<B: ratatui::backend::Backend>(
                         ToggleTaskStatusCommand.execute(&mut app);
                     }
                     KeyCode::Char('m') => {
-                        StartEditingTaskCommand.execute(&mut app);
+                        StartEditingExistingTaskCommand.execute(&mut app);
                     }
                     KeyCode::Char('p') => {
                         ToggleItemPriorityCommand.execute(&mut app);
@@ -85,16 +86,14 @@ fn run_app<B: ratatui::backend::Backend>(
                         }
                     }
                     KeyCode::Esc => {
-                        app.input_mode = InputMode::Normal;
-                        app.input_title.clear();
-                        app.input_description.clear();
+                        StopEditingCommand.execute(&mut app);
                     }
                     _ => {}
                 },
                 InputMode::EditingExisting => match key.code {
                     KeyCode::Tab => app.next_input_field(),
                     KeyCode::Enter => {
-                        FinishEditingTaskCommand.execute(&mut app);
+                        FinishEditingExistingTaskCommand.execute(&mut app);
                     }
                     KeyCode::Char(c) => {
                         match app.input_field {
@@ -109,9 +108,7 @@ fn run_app<B: ratatui::backend::Backend>(
                         }
                     }
                     KeyCode::Esc => {
-                        app.input_mode = InputMode::Normal;
-                        app.input_title.clear();
-                        app.input_description.clear();
+                        StopEditingCommand.execute(&mut app);
                     }
                     _ => {}
                 },

--- a/src/task.rs
+++ b/src/task.rs
@@ -9,7 +9,6 @@ pub enum Priority {
 }
 
 impl Priority {
-
     pub fn next(&self) -> Self {
         match self {
             Priority::Low => Priority::Medium,

--- a/src/task.rs
+++ b/src/task.rs
@@ -72,18 +72,29 @@ impl Ord for Priority {
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Task {
     pub id: i32,
+    pub title: String,
     pub description: String,
     pub completed: bool,
     pub priority: Priority,
 }
 
+impl Default for Task {
+    fn default() -> Self {
+        let mut t = Task::new();
+        t.title = "Test task title".to_string();
+        t.description = "Test task description".to_string();
+        t
+    }
+}
+
 impl Task {
-    pub fn new(id: i32, description: String) -> Self {
+    pub fn new() -> Self {
         Self {
-            id,
-            description,
+            id: 0,
+            title: String::new(),
+            description: String::new(),
             completed: false,
-            priority: Priority::Medium,
+            priority: Priority::Low,
         }
     }
 }

--- a/src/task_db.rs
+++ b/src/task_db.rs
@@ -1,6 +1,6 @@
+use crate::task::{Priority, Task};
 use anyhow::{Context, Result};
 use rusqlite::{params, Connection};
-use crate::task::{Priority, Task};
 
 #[derive(Debug)]
 pub struct DB {
@@ -12,9 +12,13 @@ impl DB {
     /// if path is an empty string creates and in memory db instance
     pub fn create_and_return_connection(path: &str) -> DB {
         let conn: Connection = if path.is_empty() {
-            Connection::open_in_memory().context("Can't open in-memory DB.").unwrap()
+            Connection::open_in_memory()
+                .context("Can't open in-memory DB.")
+                .unwrap()
         } else {
-            Connection::open(path).context("Can't open database").unwrap()
+            Connection::open(path)
+                .context("Can't open database")
+                .unwrap()
         };
         let mut db = DB { connection: conn };
         db.init();
@@ -41,9 +45,14 @@ impl DB {
         self.connection
             .execute(
                 "INSERT INTO tasks (title, description, completed, priority) VALUES (?1,?2, 0, ?3)",
-                params![task.title.trim(), task.description.trim(), task.priority.to_usize()],
+                params![
+                    task.title.trim(),
+                    task.description.trim(),
+                    task.priority.to_usize()
+                ],
             )
-            .context("Can't add task to DB.").unwrap();
+            .context("Can't add task to DB.")
+            .unwrap();
     }
 
     pub fn add_task_description(&self, description: &str) {
@@ -52,7 +61,8 @@ impl DB {
                 "INSERT INTO tasks (title, description, completed, priority) VALUES (?1,?2, 0, 2)",
                 params![" ", description.trim()],
             )
-            .context("Can't add task to DB.").unwrap();
+            .context("Can't add task to DB.")
+            .unwrap();
     }
 
     pub fn add_task_with_priority(&self, description: &str, priority: Priority) {
@@ -61,7 +71,8 @@ impl DB {
                 "INSERT INTO tasks (title, description, completed, priority) VALUES (?1,?2, 0, ?3)",
                 params![" ", description.trim(), priority as u8],
             )
-            .context("Can't add task to DB.").unwrap();
+            .context("Can't add task to DB.")
+            .unwrap();
     }
 
     pub fn get_all_tasks(&self) -> Vec<Task> {
@@ -79,7 +90,8 @@ impl DB {
                     priority: Priority::from_u8(row.get(4)?).unwrap(),
                 })
             })
-            .context("Can't get results from DB.").unwrap();
+            .context("Can't get results from DB.")
+            .unwrap();
         let mut tasks = Vec::new();
         for task in task_row_iter {
             tasks.push(task.unwrap());
@@ -88,9 +100,9 @@ impl DB {
     }
 
     pub fn get_task_by_id(&self, task_id: i32) -> Result<Task> {
-        let mut stmt = self
-            .connection
-            .prepare("SELECT id, title, description, completed, priority FROM tasks where id = ?1")?;
+        let mut stmt = self.connection.prepare(
+            "SELECT id, title, description, completed, priority FROM tasks where id = ?1",
+        )?;
         stmt.query_row(params![task_id], |row| {
             Ok(Task {
                 id: row.get(0)?,
@@ -118,7 +130,8 @@ impl DB {
                     priority: Priority::from_u8(row.get(4)?).unwrap(),
                 })
             })
-            .context("Couldn't get results from DB.").unwrap();
+            .context("Couldn't get results from DB.")
+            .unwrap();
         let mut tasks = Vec::new();
         for task in task_row_iter {
             tasks.push(task.unwrap());
@@ -141,7 +154,8 @@ impl DB {
                     priority: Priority::from_u8(row.get(4)?).unwrap(),
                 })
             })
-            .context("Couldn't get results from DB.").unwrap();
+            .context("Couldn't get results from DB.")
+            .unwrap();
         let mut tasks = Vec::new();
         for task in task_row_iter {
             tasks.push(task.unwrap());
@@ -163,7 +177,7 @@ impl DB {
             .unwrap()
     }
 
-    pub fn update_task_priority(&self, task_id: i32, priority: Priority) -> usize{
+    pub fn update_task_priority(&self, task_id: i32, priority: Priority) -> usize {
         self.connection
             .execute(
                 "UPDATE tasks SET priority = ?2 WHERE id = ?1",
@@ -173,12 +187,13 @@ impl DB {
             .unwrap()
     }
 
-    pub fn update_task(&self, task: &Task) -> usize{
+    pub fn update_task(&self, task: &Task) -> usize {
         self.connection
             .execute(
                 "UPDATE tasks SET title = ?2, description = ?3 WHERE id = ?1",
                 params![task.id, task.title, task.description],
-            ).context("Can't update the task.")
+            )
+            .context("Can't update the task.")
             .unwrap()
     }
 
@@ -191,12 +206,16 @@ impl DB {
 
     pub fn get_record_count(&self) -> i64 {
         let query = "SELECT count(*) FROM tasks";
-        self.connection.query_row(query, [], |r| r.get(0))
-            .context("Can't get record count").unwrap()
+        self.connection
+            .query_row(query, [], |r| r.get(0))
+            .context("Can't get record count")
+            .unwrap()
     }
 
     pub fn clear(&self) -> usize {
-        self.connection.execute("DELETE FROM tasks", [])
-            .context("Can't clear database").unwrap()
+        self.connection
+            .execute("DELETE FROM tasks", [])
+            .context("Can't clear database")
+            .unwrap()
     }
 }

--- a/src/task_db.rs
+++ b/src/task_db.rs
@@ -163,16 +163,6 @@ impl DB {
             .unwrap()
     }
 
-    pub fn set_task_completed(&self, task_id: i32) -> usize {
-        self.connection
-            .execute(
-                "UPDATE tasks SET completed = 1 WHERE id = ?1",
-                params![task_id],
-            )
-            .context("Can't update the task completed property.")
-            .unwrap()
-    }
-
     pub fn update_task_priority(&self, task_id: i32, priority: Priority) -> usize{
         self.connection
             .execute(
@@ -183,12 +173,12 @@ impl DB {
             .unwrap()
     }
 
-    pub fn update_task_description(&self, task_id: i32, description: &str) -> usize {
+    pub fn update_task(&self, task: &Task) -> usize{
         self.connection
             .execute(
-                "UPDATE tasks SET description = ?2 WHERE id = ?1",
-                params![task_id, description],
-            ).context("Can't update the task description property.")
+                "UPDATE tasks SET title = ?2, description = ?3 WHERE id = ?1",
+                params![task.id, task.title, task.description],
+            ).context("Can't update the task.")
             .unwrap()
     }
 

--- a/src/task_manager.rs
+++ b/src/task_manager.rs
@@ -31,13 +31,8 @@ impl TasksService {
         }
     }
 
-    /// Add a new task
-    pub fn add_task(&self, description: String) {
-        self.db.add_task(&description)
-    }
-
-    pub fn add_task_with_priority(&self, description: String, priority: Priority) {
-        self.db.add_task_with_priority(&description, priority)
+    pub fn add_new_task(&self, task: &Task) {
+        self.db.insert_task(task);
     }
 
     /// Get a task with `task_id`. Returns an Option containing the task or None

--- a/src/task_manager.rs
+++ b/src/task_manager.rs
@@ -56,14 +56,14 @@ impl TasksService {
     }
 
     /// Return all the tasks sorted by `sort`
-    pub fn get_all_tasks_sorted(&self, sort:SortOrder) -> Vec<Task> {
+    pub fn get_all_tasks_sorted(&self, sort: SortOrder) -> Vec<Task> {
         match sort {
             SortOrder::High => self.db.get_all_task_by_highest_priority(),
             SortOrder::Low => self.db.get_all_task_by_lowest_priority(),
         }
     }
 
-    pub fn toggle_task_status(&self, task_id: i32, completed: bool) -> usize{
+    pub fn toggle_task_status(&self, task_id: i32, completed: bool) -> usize {
         self.db.toggle_task_completed(task_id, completed)
     }
 
@@ -72,7 +72,7 @@ impl TasksService {
         self.db.update_task_priority(task_id, priority.to_owned())
     }
 
-    pub fn update_task(&self, task: &Task){
+    pub fn update_task(&self, task: &Task) {
         self.db.update_task(task);
     }
 

--- a/src/task_manager.rs
+++ b/src/task_manager.rs
@@ -63,13 +63,8 @@ impl TasksService {
         }
     }
 
-    /// Mark a task completed with `task_id` number
-    pub fn mark_completed(&self, task_id: i32) -> usize {
-        self.db.set_task_completed(task_id)
-    }
-
-    pub fn toggle_task_status(&self, task_id: i32, completed: bool){
-        self.db.toggle_task_completed(task_id, completed);
+    pub fn toggle_task_status(&self, task_id: i32, completed: bool) -> usize{
+        self.db.toggle_task_completed(task_id, completed)
     }
 
     /// Change priority of the task
@@ -77,8 +72,8 @@ impl TasksService {
         self.db.update_task_priority(task_id, priority.to_owned())
     }
 
-    pub fn update_description(&self, task_id: i32, description: &str){
-        self.db.update_task_description(task_id, description);
+    pub fn update_task(&self, task: &Task){
+        self.db.update_task(task);
     }
 
     /// Delete a task with `task_id` number

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -164,7 +164,7 @@ impl From<&Task> for ListItem<'_> {
                 Style::default().fg(priority_to_color(&value.priority)),
             ),
             Span::styled(
-                format!(" {}", value.description),
+                format!(" {} - {}",value.title,  value.description),
                 Style::default().fg(TEXT_FG_COLOR),
             ),
         ];
@@ -175,7 +175,7 @@ impl From<&Task> for ListItem<'_> {
                 Style::default().fg(priority_to_color(&value.priority)),
             ),
             Span::styled(
-                format!(" {}", value.description),
+                format!(" {} - {}",value.title,  value.description),
                 Style::default().fg(COMPLETED_TEXT_FG_COLOR),
             ),
         ];

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -13,11 +13,7 @@ const TEXT_FG_COLOR: Color = SLATE.c200;
 const COMPLETED_TEXT_FG_COLOR: Color = SLATE.c500;
 
 pub fn ui(f: &mut Frame, app: &mut App) {
-    let [
-    main_area,
-    input_title_area,
-    input_description_area,
-    message_area] = Layout::vertical([
+    let [main_area, input_title_area, input_description_area, message_area] = Layout::vertical([
         Constraint::Min(1),
         Constraint::Length(3),
         Constraint::Length(3),
@@ -27,17 +23,18 @@ pub fn ui(f: &mut Frame, app: &mut App) {
     .areas(f.area());
 
     match app.input_mode {
-        InputMode::Normal => {
-        }
+        InputMode::Normal => {}
         InputMode::Editing | InputMode::EditingExisting => {
             let input_area = match app.input_field {
                 InputField::Title => input_title_area,
                 InputField::Description => input_description_area,
             };
-            let x = input_area.x + match app.input_field {
-                InputField::Title => app.input_title.len() as u16,
-                InputField::Description => app.input_description.len() as u16,
-            } + 1;
+            let x = input_area.x
+                + match app.input_field {
+                    InputField::Title => app.input_title.len() as u16,
+                    InputField::Description => app.input_description.len() as u16,
+                }
+                + 1;
             let y = input_area.y + 1;
             f.set_cursor_position(Position::new(x, y))
         }
@@ -47,8 +44,6 @@ pub fn ui(f: &mut Frame, app: &mut App) {
     render_input_title_area(f, app, input_title_area);
     render_input_description_area(f, app, input_description_area);
     render_message_area(f, app, message_area);
-
-
 }
 
 fn render_list(f: &mut Frame, app: &mut App, area: Rect) {
@@ -83,11 +78,7 @@ fn render_input_title_area(f: &mut Frame, app: &mut App, area: Rect) {
             InputMode::Editing => Style::default().fg(Color::Yellow),
             InputMode::EditingExisting => Style::default().fg(Color::Cyan),
         })
-        .block(
-            Block::default()
-                .borders(Borders::BOTTOM)
-                .title("Title"),
-        );
+        .block(Block::default().borders(Borders::BOTTOM).title("Title"));
     f.render_widget(input, area);
 }
 
@@ -164,7 +155,7 @@ impl From<&Task> for ListItem<'_> {
                 Style::default().fg(priority_to_color(&value.priority)),
             ),
             Span::styled(
-                format!(" {} - {}",value.title,  value.description),
+                format!(" {} - {}", value.title, value.description),
                 Style::default().fg(TEXT_FG_COLOR),
             ),
         ];
@@ -175,7 +166,7 @@ impl From<&Task> for ListItem<'_> {
                 Style::default().fg(priority_to_color(&value.priority)),
             ),
             Span::styled(
-                format!(" {} - {}",value.title,  value.description),
+                format!(" {} - {}", value.title, value.description),
                 Style::default().fg(COMPLETED_TEXT_FG_COLOR),
             ),
         ];

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,11 +1,11 @@
-use ratatui::{symbols, Frame};
-use ratatui::layout::{Constraint, Layout, Rect};
+use crate::app::{App, InputField, InputMode};
+use crate::task::{Priority, Task};
+use ratatui::layout::{Constraint, Layout, Position, Rect};
 use ratatui::prelude::{Color, Line, Modifier, Span, StatefulWidget, Style};
 use ratatui::style::palette::tailwind::{BLUE, SLATE};
 use ratatui::style::Stylize;
 use ratatui::widgets::{Block, Borders, HighlightSpacing, List, ListItem, Paragraph};
-use crate::app::{App, InputMode};
-use crate::task::{Priority, Task};
+use ratatui::{symbols, Frame};
 const TODO_HEADER_STYLE: Style = Style::new().fg(SLATE.c100).bg(BLUE.c800);
 const NORMAL_ROW_BG: Color = SLATE.c950;
 const SELECTED_STYLE: Style = Style::new().bg(SLATE.c800).add_modifier(Modifier::BOLD);
@@ -13,22 +13,47 @@ const TEXT_FG_COLOR: Color = SLATE.c200;
 const COMPLETED_TEXT_FG_COLOR: Color = SLATE.c500;
 
 pub fn ui(f: &mut Frame, app: &mut App) {
-    let [main_area, input_area, message_area] = Layout::vertical([
+    let [
+    main_area,
+    input_title_area,
+    input_description_area,
+    message_area] = Layout::vertical([
         Constraint::Min(1),
+        Constraint::Length(3),
         Constraint::Length(3),
         Constraint::Length(1),
     ])
-        .margin(2)
-        .areas(f.area());
+    .margin(2)
+    .areas(f.area());
+
+    match app.input_mode {
+        InputMode::Normal => {
+        }
+        InputMode::Editing | InputMode::EditingExisting => {
+            let input_area = match app.input_field {
+                InputField::Title => input_title_area,
+                InputField::Description => input_description_area,
+            };
+            let x = input_area.x + match app.input_field {
+                InputField::Title => app.input_title.len() as u16,
+                InputField::Description => app.input_description.len() as u16,
+            } + 1;
+            let y = input_area.y + 1;
+            f.set_cursor_position(Position::new(x, y))
+        }
+    }
 
     render_list(f, app, main_area);
-    render_input_area(f, app, input_area);
+    render_input_title_area(f, app, input_title_area);
+    render_input_description_area(f, app, input_description_area);
     render_message_area(f, app, message_area);
+
+
 }
 
 fn render_list(f: &mut Frame, app: &mut App, area: Rect) {
     let block = Block::new()
-        .title(Line::raw("TODO List").centered())
+        .title(Line::raw("Task Rustler").centered())
         .borders(Borders::TOP)
         .border_set(symbols::border::EMPTY)
         .border_style(TODO_HEADER_STYLE)
@@ -51,22 +76,34 @@ fn render_list(f: &mut Frame, app: &mut App, area: Rect) {
     StatefulWidget::render(list, area, f.buffer_mut(), &mut app.task_list.state);
 }
 
-fn render_input_area(f: &mut Frame, app: &mut App, area: Rect) {
-    let input = Paragraph::new(app.input.as_str())
+fn render_input_title_area(f: &mut Frame, app: &mut App, area: Rect) {
+    let input = Paragraph::new(app.input_title.as_str())
         .style(match app.input_mode {
             InputMode::Normal => Style::default(),
             InputMode::Editing => Style::default().fg(Color::Yellow),
             InputMode::EditingExisting => Style::default().fg(Color::Cyan),
         })
-        .block(Block::default().borders(Borders::ALL).title("Input"));
+        .block(
+            Block::default()
+                .borders(Borders::BOTTOM)
+                .title("Title"),
+        );
     f.render_widget(input, area);
+}
 
-    match app.input_mode {
-        InputMode::Normal => {}
-        InputMode::Editing | InputMode::EditingExisting => {
-            f.set_cursor(area.x + app.input.len() as u16 + 1, area.y + 1)
-        }
-    }
+fn render_input_description_area(f: &mut Frame, app: &mut App, area: Rect) {
+    let input = Paragraph::new(app.input_description.as_str())
+        .style(match app.input_mode {
+            InputMode::Normal => Style::default(),
+            InputMode::Editing => Style::default().fg(Color::Yellow),
+            InputMode::EditingExisting => Style::default().fg(Color::Cyan),
+        })
+        .block(
+            Block::default()
+                .borders(Borders::BOTTOM)
+                .title("Description"),
+        );
+    f.render_widget(input, area);
 }
 
 fn render_message_area(f: &mut Frame, app: &mut App, area: Rect) {

--- a/tests/test_task_service.rs
+++ b/tests/test_task_service.rs
@@ -63,9 +63,9 @@ mod test {
     #[test]
     fn set_completed_should_return_1_if_task_exists_0_otherwise() {
         let t = setup();
-        let num_tasks_completed = t.mark_completed(1);
+        let num_tasks_completed = t.toggle_task_status(1, true);
         assert_eq!(num_tasks_completed, 1);
-        let num_tasks_completed = t.mark_completed(100);
+        let num_tasks_completed = t.toggle_task_status(100, true);
         assert_eq!(num_tasks_completed, 0);
     }
 

--- a/tests/test_task_service.rs
+++ b/tests/test_task_service.rs
@@ -9,25 +9,28 @@ mod test {
         let tasks_to_add = vec![
             Task {
                 id: 1,
+                title: "My first task title".to_string(),
                 description: "First task".to_string(),
                 completed: false,
                 priority: Priority::Low,
             },
             Task {
                 id: 2,
+                title: "My second task title".to_string(),
                 description: "Second task".to_string(),
                 completed: false,
                 priority: Priority::Medium,
             },
             Task {
                 id: 3,
+                title: "My third task title".to_string(),
                 description: "Third task".to_string(),
                 completed: false,
                 priority: Priority::High,
             },
         ];
         for t in tasks_to_add {
-            tasks.add_task_with_priority(t.description, t.priority);
+            tasks.add_new_task(&t)
         }
         tasks
     }
@@ -45,10 +48,10 @@ mod test {
     #[test]
     fn should_return_task_if_id_exists() {
         let t = setup();
-        t.add_task("Hi".to_string());
+        t.add_new_task(&Task::default());
         let task = t.get_task(4).unwrap();
         assert_eq!(task.id, 4);
-        assert_eq!(task.description, "Hi");
+        assert_eq!(task.description, "Test task description");
         assert_eq!(task.completed, false);
     }
     #[test]
@@ -83,6 +86,7 @@ mod test {
             tasks[0],
             Task {
                 id: 3,
+                title: "My third task title".to_string(),
                 description: "Third task".to_string(),
                 completed: false,
                 priority: Priority::High,
@@ -98,6 +102,7 @@ mod test {
             tasks[0],
             Task {
                 id: 1,
+                title: "My first task title".to_string(),
                 description: "First task".to_string(),
                 completed: false,
                 priority: Priority::Low,


### PR DESCRIPTION
- Now **task rustler** can modify and save title input field.
  - Refactored dao and service code so you just pass a **Task** instance when you want to modify  or save a task instead to pass every single field.
- Moved all commands into **command.rs**  